### PR TITLE
matrix only impl

### DIFF
--- a/R/int_gencat.R
+++ b/R/int_gencat.R
@@ -9,39 +9,20 @@
 
 gencat <- function(n, formula, dfSim) {
 
-  # 'declare var
+    # parse formula
 
-  V1 = NULL
+    pstr <- unlist(strsplit(as.character(formula), split = ";", fixed = TRUE))
 
-  #
+    # build command and parameters
 
-  pstr <- unlist(strsplit(as.character(formula),split=";", fixed=TRUE))
-  idname <- names(dfSim)[1]
+    cmd <- substitute(
+      (t(stats::rmultinom(nsamp, 1, probs)) %*% c(1:nparam))[,1],
+      list(nsamp  = n,
+           probs  = as.numeric(pstr),
+           nparam = length(pstr))
+    )
 
-  dtSim <- data.table::data.table(dfSim)
+    # evaluate and return
 
-  ps <- paste0(pstr, collapse=",")
-  ps <- paste0("c(", ps, ")")
-
-  nparam = length(pstr)
-
-  # build command based on parameters "ps"
-
-  cmd  <- quote(x[, 1]) # x is [[2]]
-  mcmd <- quote(x %*% c(1:nparam)) # x is [[2]]
-  tcmd <- quote(t(x)) # x is [[2]]
-  pcmd <- quote(stats::rmultinom(nrow(dtSim), 1, x)) # x is [[4]]
-
-  pcmd[[4]] <- parse(text=ps)[[1]]
-  tcmd[[2]] <- pcmd
-  mcmd[[2]] <- tcmd
-  cmd[[2]]  <- mcmd
-
-  # if (!all(apply(p,1,sum) == 1)) {
-  #   stop("Sums for cumulative probabilities in categorical distribution not 1")
-  # }
-
-  new <- eval(cmd)
-
-  return(new)
+    return(eval(cmd))
 }

--- a/R/int_gencat.R
+++ b/R/int_gencat.R
@@ -27,22 +27,21 @@ gencat <- function(n, formula, dfSim) {
 
   # build command based on parameters "ps"
 
-  cmd  <- quote(dtSim[ , x , keyby = y])
-  mcmd <- quote(x %*% c(1:nparam)) # x is 2
-  tcmd <- quote(t(x)) # x is 2
-  pcmd <- quote(stats::rmultinom(1, 1, x))
+  cmd  <- quote(x[, 1]) # x is [[2]]
+  mcmd <- quote(x %*% c(1:nparam)) # x is [[2]]
+  tcmd <- quote(t(x)) # x is [[2]]
+  pcmd <- quote(stats::rmultinom(nrow(dtSim), 1, x)) # x is [[4]]
 
   pcmd[[4]] <- parse(text=ps)[[1]]
   tcmd[[2]] <- pcmd
   mcmd[[2]] <- tcmd
-  cmd[[4]]  <- mcmd
-  cmd[[5]]  <- parse(text=idname)[[1]]
+  cmd[[2]]  <- mcmd
 
   # if (!all(apply(p,1,sum) == 1)) {
   #   stop("Sums for cumulative probabilities in categorical distribution not 1")
   # }
 
-  new <- eval(cmd)[,V1]
+  new <- eval(cmd)
 
   return(new)
 }


### PR DESCRIPTION
I noticed that generation of categorical data was rather slow compared to the generation of other distributions.  This pull request represents my attempt to make categorical generation much faster, by using only matrix operations, i.e. without `data.table` subsetting (cf. [line #30](https://github.com/kgoldfeld/simstudy/blob/master/R/int_gencat.R#L30) in `master`).

With the changes in place, generation time is dramatically reduced, e.g. for sample sizes in the millions.

Let `sim.dt` be a table returned from `simstudy::genData`; I spot-tested whether the categorical distribution conformed to the specified probabilities like so:

```R
fact <- as.factor(sim.dt$xCat)
smry <- summary(fact)
smry/sum(smry)
```

And indeed that appeared to be the case. Let me know if/how I can make this pull request better, and I will be happy to do so.