### PR TITLE
Fix .genQuantU command to include corMatrix.

### DIFF
--- a/R/genCorOrdCat.R
+++ b/R/genCorOrdCat.R
@@ -95,7 +95,7 @@ genCorOrdCat <- function(dtName, idname = "id", adjVar = NULL, baseprobs,
   
   N <- nrow(dtName)
   nq <- nrow(baseprobs)
-  zs <- .genQuantU(nq, N, rho = rho, corstr, corMatrix = NULL)
+  zs <- .genQuantU(nq, N, rho = rho, corstr, corMatrix = corMatrix)
   zs[, logisZ := stats::qlogis(p = zs$Unew)]
   cprop <- t(apply(baseprobs, 1, cumsum))
   quant <- t(apply(cprop, 1, stats::qlogis))


### PR DESCRIPTION
Changed the corMatrix argument in the .genQuantU command to accept the corMatrix provided by the user.