### PR TITLE
Bugfix incorrect lower bound calculation in .checkBoundsBin() function

### DIFF
--- a/R/int_binEPmethod.R
+++ b/R/int_binEPmethod.R
@@ -18,7 +18,7 @@
       
       if (d < L | d > U)   {
         LU <- paste0("(", round(L,2) , " ... ", round(U, 2), ")")
-        stopText <- paste("Sepcified correlation", d, "out of range" , LU)
+        stopText <- paste("Specified correlation", d, "out of range" , LU)
         stop(stopText)
       }
 }

--- a/R/int_binEPmethod.R
+++ b/R/int_binEPmethod.R
@@ -10,7 +10,7 @@
 
 .checkBoundsBin <- function(p1, p2, d) {
 
-      l <- (p1*p2) / (1-p1)*(1-p2)
+      l <- (p1*p2) / ((1-p1)*(1-p2))
       L <- max(-sqrt(l), -sqrt(1/l))
       
       u <- (p1*(1-p2)) / (p2*(1-p1))

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(simstudy)
+
+test_check("simstudy")

--- a/tests/testthat/test_checkBoundsBin.R
+++ b/tests/testthat/test_checkBoundsBin.R
@@ -6,10 +6,10 @@ test_that("Correlation boundaries for binary variables are correct", {
   p1 <- mean(x1)
   p2 <- mean(x2)
   
-  expect_error(checkBoundsBin(p1, p2, -1))
+  expect_error(.checkBoundsBin(p1, p2, -1))
   
-  expect_silent(checkBoundsBin(p1, p2, -0.6))
-  expect_silent(checkBoundsBin(p1, p2, 0.4))
-  expect_silent(checkBoundsBin(p1, p2, cor(x1, x2)))
+  expect_silent(.checkBoundsBin(p1, p2, -0.6))
+  expect_silent(.checkBoundsBin(p1, p2, 0.4))
+  expect_silent(.checkBoundsBin(p1, p2, round(cor(x1, x2), 5)))
   
 })

--- a/tests/testthat/test_checkBoundsBin.R
+++ b/tests/testthat/test_checkBoundsBin.R
@@ -1,0 +1,15 @@
+
+test_that("Correlation boundaries for binary variables are correct", {
+  x1 <- c(0, 0, 0, 1, 0)
+  x2 <- c(1, 1, 1, 0, 0)
+  
+  p1 <- mean(x1)
+  p2 <- mean(x2)
+  
+  expect_error(checkBoundsBin(p1, p2, -1))
+  
+  expect_silent(checkBoundsBin(p1, p2, -0.6))
+  expect_silent(checkBoundsBin(p1, p2, 0.4))
+  expect_silent(checkBoundsBin(p1, p2, cor(x1, x2)))
+  
+})


### PR DESCRIPTION
Hi!
While playing around with your nice package, I ran into a bug with `.checkBoundsBin()`
The lower boundary was not calculated correctly because of missing parentheses in the denominator.

A colleague of mine suggested to add a unit test for this function as an example of how easy it is to create a few unit tests when developing code. This is my first unit test ever, but i found he was right, it is really straightforward. It uses the ``testthat`` framework that is widely used for R packages.

Using devtools::install(), the package compiles, runs the tests, and installs without problems on my machine.

regards,
Gertjan

