### PR TITLE
Improve genBinEP()

### DIFF
--- a/R/int_binEPmethod.R
+++ b/R/int_binEPmethod.R
@@ -1,4 +1,4 @@
-#### Impletment Emrich and Piedmonte algorithm for correlated binary data ####
+#### Implement Emrich and Piedmonte algorithm for correlated binary data ####
 
 # Internal functions called by genCorGen and addCorGen - returns matrix
 #
@@ -30,7 +30,7 @@
   
   target <- d*sqrt(p1*p2*(1-p1)*(1-p2)) + p1*p2
   
-  # given p1, p2 & d, biesection search for corresponding rho
+  # given p1, p2 & d, bisection search for corresponding rho
   
   Max <- 1
   Min <- -1
@@ -82,6 +82,12 @@
       
       phicorr[j, i] <- phicorr[i, j] <- .findRhoBin(p1, p2, tcorr[i, j])
     }
+    
+  }
+  
+  # check that phicorr is positive definite (PD), if not adjust to nearest PD matrix
+  if (!all(eigen(phicorr)$values > 0)) {
+    phicorr <- Matrix::nearPD(phicorr)$mat
     
   }
   

--- a/R/int_binEPmethod.R
+++ b/R/int_binEPmethod.R
@@ -16,7 +16,8 @@
       u <- (p1*(1-p2)) / (p2*(1-p1))
       U <- min(sqrt(u), sqrt(1/u))  
       
-      if (d < L | d > U)   {
+      if ((d < L & isTRUE(all.equal(d, L)) == FALSE) | 
+          (d > U & isTRUE(all.equal(d, U)) == FALSE))   {
         LU <- paste0("(", round(L,2) , " ... ", round(U, 2), ")")
         stopText <- paste("Specified correlation", d, "out of range" , LU)
         stop(stopText)

--- a/tests/testthat/test_checkBoundsBin.R
+++ b/tests/testthat/test_checkBoundsBin.R
@@ -10,6 +10,6 @@ test_that("Correlation boundaries for binary variables are correct", {
   
   expect_silent(.checkBoundsBin(p1, p2, -0.6))
   expect_silent(.checkBoundsBin(p1, p2, 0.4))
-  expect_silent(.checkBoundsBin(p1, p2, round(cor(x1, x2), 5)))
+  expect_silent(.checkBoundsBin(p1, p2, cor(x1, x2)))
   
 })


### PR DESCRIPTION
Hi!
In the process of trying to convert an existing dataset of 400 binary correlated variables into a simulated one usin the EP method, I ran into two problems:

The first was that when comparing the allowed ranges `.checkBoundsBin()`, some correlations were deemed outside the boundary, whereas they were actually exactly permitted (i.e. exactly the lowest correlation possible, see for an example the two binary vectors` x1` and `x2 `in the test file).
I solved this using `isTRUE(all.equal(x, y))`.

The second was that the intermediate correlation matrix is not always positive definite (this was increasingly likely when adding more and more variables) and `mvnfast()` would throw an error. I solved this using the `Matrix::nearPD()` function, that changes a matrix slightly such that it becomes positive definite. 

I checked that this code builds and installs, and can confirm that it now can actually simulate a multivariate dataset of 400 correlated binary variables! 
