### PR TITLE
Manage double-dot environments

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,6 +1,8 @@
 on:
   push:
-    branches: release
+    branches: 
+      - main
+      - release
 
 name: pkgdown
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: simstudy
 Title: Simulation of Study Data
-Version: 0.2.0
+Version: 0.1.16.9000
 Date: 2020-09-25
 Authors@R: 
     c(person(given = "Keith",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 * Moved genCorOrdCat's functionality into genOrdCat. genCorOrdCat is now
   deprecated.
 * Introduced a new system for formula definitions and completely reworked the
-  underlying code. See vignette "NAME".
+  underlying code. See vignette "double-dot".
 * Added new vignettes.
 * Created documentation page: https://kgoldfeld.github.io/simstudy/
 * Fixed bug in trtAssign related new ratio argument.

--- a/R/add_data.R
+++ b/R/add_data.R
@@ -2,6 +2,8 @@
 #'
 #' @param dtDefs name of definitions for added columns
 #' @param dtOld name of data table that is to be updated
+#' @param envir Environment the data definitions are evaluated in.
+#'  Defaults to [base::parent.frame].
 #' @return an updated data.table that contains the added simulated data
 #' @examples
 #' # New data set
@@ -20,8 +22,9 @@
 #' dt <- addColumns(def2, dt)
 #' dt
 #' @concept generate_data
+#' @md
 #' @export
-addColumns <- function(dtDefs, dtOld) {
+addColumns <- function(dtDefs, dtOld, envir = parent.frame()) {
 
   # "declares" varname to avoid global NOTE
   varname <- NULL
@@ -52,7 +55,13 @@ addColumns <- function(dtDefs, dtOld) {
   iter <- nrow(dtDefs)
   n <- nrow(dtOld)
   for (i in (1:iter)) {
-    dtOld <- .generate(dtDefs[i, ], n, dtOld, oldkey)
+    dtOld <- .generate(
+      args = dtDefs[i, ],
+      n = n,
+      dfSim = dtOld,
+      idname = oldkey,
+      envir = envir
+    )
   }
 
   dtOld <- data.table::data.table(dtOld)
@@ -66,7 +75,8 @@ addColumns <- function(dtDefs, dtOld) {
 #' @param condDefs Name of definitions for added column
 #' @param dtOld Name of data table that is to be updated
 #' @param newvar Name of new column to add
-#'
+#' @param envir Environment the data definitions are evaluated in.
+#'  Defaults to [base::parent.frame].
 #' @return An updated data.table that contains the added simulated data
 #' @examples
 #'
@@ -103,9 +113,10 @@ addColumns <- function(dtDefs, dtOld) {
 #' ggplot(data = dt, aes(x = y, y = NewVar, group = x)) +
 #'   geom_point(aes(color = factor(x)))
 #' @export
+#' @md
 #' @concept generate_data
 #' @concept condition
-addCondition <- function(condDefs, dtOld, newvar) {
+addCondition <- function(condDefs, dtOld, newvar, envir = parent.frame()) {
 
   # 'declare' vars
   varname <- NULL
@@ -163,7 +174,13 @@ addCondition <- function(condDefs, dtOld, newvar) {
     n <- nrow(dtTemp)
 
     if (n > 0) {
-      dtTemp <- .generate(cDefs[i, ], n, dtTemp, oldkey)
+      dtTemp <- .generate(
+        args = cDefs[i, ],
+        n = n,
+        dfSim = dtTemp,
+        idname =  oldkey,
+        envir = envir
+      )
 
       dtTemp <- data.table::data.table(dtTemp)
       dtTemp <- dtTemp[, list(get(oldkey), get(newvar))]

--- a/R/define_data.R
+++ b/R/define_data.R
@@ -89,7 +89,7 @@ defCondition <- function(dtDefs = NULL,
 #' @details The possible data distributions are: `r paste0(.getDists(),collapse = ", ")`.
 #'
 #' @examples
-#' extVar <<- 2.3
+#' extVar <- 2.3
 #' def <- defData(varname = "xNr", dist = "nonrandom", formula = 7, id = "idnum")
 #' def <- defData(def, varname = "xUni", dist = "uniform", formula = "10;20")
 #' def <- defData(def,

--- a/R/generate_data.R
+++ b/R/generate_data.R
@@ -5,8 +5,11 @@
 #'  are provided
 #' a data set with ids only is generated.
 #' @param id The string defining the id of the record
+#' @param envir Environment the data definitions are evaluated in.
+#'  Defaults to [base::parent.frame].
 #' @return A data.table that contains the simulated data.
 #' @export
+#' @md
 #' @concept generate_data
 #' @examples
 #' genData(5)
@@ -43,7 +46,7 @@
 #' def
 #'
 #' genData(5, def)
-genData <- function(n, dtDefs = NULL, id = "id") {
+genData <- function(n, dtDefs = NULL, id = "id", envir = parent.frame()) {
   assertNotMissing(n = missing(n))
   assertValue(n = n, id = id)
   assertType(id = id, type = "character")
@@ -63,7 +66,13 @@ genData <- function(n, dtDefs = NULL, id = "id") {
     iter <- nrow(dtDefs) # generate a column of data for each row of dtDefs
 
     for (i in (1:iter)) {
-      dfSimulate <- .generate(dtDefs[i, ], n, dfSimulate, idname)
+      dfSimulate <- .generate(
+        args = dtDefs[i, ],
+        n = n,
+        dfSim = dfSimulate,
+        idname = idname,
+        envir = envir
+      )
     }
 
     dt <- data.table::data.table(dfSimulate)

--- a/R/internal_utility.R
+++ b/R/internal_utility.R
@@ -13,13 +13,13 @@
 #' .parseDotVars(c("a + ..extVar1", "b + ..extVar2"))
 #' .parseDotVars(data.frame("a + ..extVar1", "b + ..extVar2"))
 #' @noRd
-.parseDotVars <- function(formula) {
+.parseDotVars <- function(formula, envir = parent.frame()) {
   vars <- all.vars(parse(text = formula))
   dotVars <- startsWith(vars, "..")
   # TODO clarify inheritance in case of non globalEnvs in documentation
   varValues <- mget(
     sub("..", "", vars[dotVars]),
-    envir = parent.frame(),
+    envir = envir,
     inherits = TRUE,
     ifnotfound = NA
   )

--- a/R/simstudy-package.R
+++ b/R/simstudy-package.R
@@ -51,7 +51,7 @@ NULL
 #'  `p_1,...,p_n`. For more information see
 #'  [rdatagen.net](https://www.rdatagen.net/post/adding-mixture-distributions-to-simstudy/).
 #' @examples
-#' ext_var <<- 2.9
+#' ext_var <- 2.9
 #' def <- defData(varname = "external", formula = "3 + log(..ext_var)", variance = .5)
 #' def
 #' genData(5, def)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -3,6 +3,8 @@ useurl: https://kgoldfeld.github.io/simstudy
 authors:
   Keith Goldfeld:
     href: "https://www.rdatagen.net/"
+development: 
+  mode: auto
 reference:
 - title: Define Data
 - contents:

--- a/man/addColumns.Rd
+++ b/man/addColumns.Rd
@@ -4,12 +4,15 @@
 \alias{addColumns}
 \title{Add columns to existing data set}
 \usage{
-addColumns(dtDefs, dtOld)
+addColumns(dtDefs, dtOld, envir = parent.frame())
 }
 \arguments{
 \item{dtDefs}{name of definitions for added columns}
 
 \item{dtOld}{name of data table that is to be updated}
+
+\item{envir}{Environment the data definitions are evaluated in.
+Defaults to \link[base:sys.parent]{base::parent.frame}.}
 }
 \value{
 an updated data.table that contains the added simulated data

--- a/man/addCondition.Rd
+++ b/man/addCondition.Rd
@@ -4,7 +4,7 @@
 \alias{addCondition}
 \title{Add a single column to existing data set based on a condition}
 \usage{
-addCondition(condDefs, dtOld, newvar)
+addCondition(condDefs, dtOld, newvar, envir = parent.frame())
 }
 \arguments{
 \item{condDefs}{Name of definitions for added column}
@@ -12,6 +12,9 @@ addCondition(condDefs, dtOld, newvar)
 \item{dtOld}{Name of data table that is to be updated}
 
 \item{newvar}{Name of new column to add}
+
+\item{envir}{Environment the data definitions are evaluated in.
+Defaults to \link[base:sys.parent]{base::parent.frame}.}
 }
 \value{
 An updated data.table that contains the added simulated data

--- a/man/addCorFlex.Rd
+++ b/man/addCorFlex.Rd
@@ -4,12 +4,20 @@
 \alias{addCorFlex}
 \title{Create multivariate (correlated) data - for general distributions}
 \usage{
-addCorFlex(dt, defs, rho = 0, tau = NULL, corstr = "cs", corMatrix = NULL)
+addCorFlex(
+  dt,
+  defs,
+  rho = 0,
+  tau = NULL,
+  corstr = "cs",
+  corMatrix = NULL,
+  envir = parent.frame()
+)
 }
 \arguments{
 \item{dt}{Data table that will be updated.}
 
-\item{defs}{Field definition table created by function `defDataAdd`.}
+\item{defs}{Field definition table created by function \code{defDataAdd}.}
 
 \item{rho}{Correlation coefficient, -1 <= rho <= 1. Use if corMatrix is not
 provided.}
@@ -26,6 +34,9 @@ and "ar1" for an autoregressive structure. Defaults to "cs".}
 symmetrical and positive semi-definite. It is not a required field; if a
 matrix is not provided, then a structure and correlation coefficient rho must
 be specified.}
+
+\item{envir}{Environment the data definitions are evaluated in.
+Defaults to \link[base:sys.parent]{base::parent.frame}.}
 }
 \value{
 data.table with added column(s) of correlated data

--- a/man/defData.Rd
+++ b/man/defData.Rd
@@ -39,7 +39,7 @@ Add single row to definitions table
 The possible data distributions are: normal, binary, binomial, poisson, noZeroPoisson, uniform, categorical, gamma, beta, nonrandom, uniformInt, negBinomial, exponential, mixture.
 }
 \examples{
-extVar <<- 2.3
+extVar <- 2.3
 def <- defData(varname = "xNr", dist = "nonrandom", formula = 7, id = "idnum")
 def <- defData(def, varname = "xUni", dist = "uniform", formula = "10;20")
 def <- defData(def,

--- a/man/distributions.Rd
+++ b/man/distributions.Rd
@@ -62,7 +62,7 @@ part of the new distribution \verb{x_1,...,X_n} is assigned a probability
 }
 
 \examples{
-ext_var <<- 2.9
+ext_var <- 2.9
 def <- defData(varname = "external", formula = "3 + log(..ext_var)", variance = .5)
 def
 genData(5, def)

--- a/man/genData.Rd
+++ b/man/genData.Rd
@@ -4,16 +4,19 @@
 \alias{genData}
 \title{Calling function to simulate data}
 \usage{
-genData(n, dtDefs = NULL, id = "id")
+genData(n, dtDefs = NULL, id = "id", envir = parent.frame())
 }
 \arguments{
 \item{n}{the number of observations required in the data set.}
 
 \item{dtDefs}{name of definitions data.table/data.frame. If no definitions
- are provided
+are provided
 a data set with ids only is generated.}
 
 \item{id}{The string defining the id of the record}
+
+\item{envir}{Environment the data definitions are evaluated in.
+Defaults to \link[base:sys.parent]{base::parent.frame}.}
 }
 \value{
 A data.table that contains the simulated data.

--- a/tests/testthat/test-generate_dist.R
+++ b/tests/testthat/test-generate_dist.R
@@ -1,7 +1,7 @@
 # .gencat ----
 test_that(".gencat throws errors", {
-  expect_error(.gencat(n, "1;", "identity", NULL), "two probabilities")
-  expect_error(.gencat(n, "1; ", "identity", NULL), "two probabilities")
+  expect_error(.gencat(n, "1;", "identity", NULL, environment()), "two probabilities")
+  expect_error(.gencat(n, "1; ", "identity", NULL, environment()), "two probabilities")
 })
 
 # .genunif ----
@@ -12,10 +12,10 @@ test_that("unif data is generated as expected.", {
 
   dt <- genData(n, def)
   dterr <- genData(n - 5, def)
-  expect_error(.genunif(n, "test;test2", dterr), "Length mismatch")
-  expect_length(.genunif(n, "test;test2", dt), n)
-  expect_true(all(!is.na(.genunif(n, "test;test2", dt))))
-  expect_length(.genunif(n, "1.3;100.2", dt), n)
+  expect_error(.genunif(n, "test;test2", dterr, environment()), "Length mismatch")
+  expect_length(.genunif(n, "test;test2", dt, environment()), n)
+  expect_true(all(!is.na(.genunif(n, "test;test2", dt, environment()))))
+  expect_length(.genunif(n, "1.3;100.2", dt, environment()), n)
 })
 
 test_that("'uniform' formula checked correctly", {
@@ -28,14 +28,14 @@ test_that("'uniform' formula checked correctly", {
       x
     }),
     function(x) {
-      expect_silent(.genunif(x$n, x$range, NULL))
+      expect_silent(.genunif(x$n, x$range, NULL, environment()))
     }
   )
 
-  expect_warning(.genunif(3, "1;1", NULL), "are equal")
-  expect_error(.genunif(3, "", NULL), "format")
-  expect_error(.genunif(3, "1;2;3", NULL), "format")
-  expect_error(.genunif(3, "2;1", NULL), "'max' < 'min'")
+  expect_warning(.genunif(3, "1;1", NULL, environment()), "are equal")
+  expect_error(.genunif(3, "", NULL, environment()), "format")
+  expect_error(.genunif(3, "1;2;3", NULL, environment()), "format")
+  expect_error(.genunif(3, "2;1", NULL, environment()), "'max' < 'min'")
 })
 
 # .genUnifInt ----
@@ -47,9 +47,9 @@ test_that("unifInt data is generated as expected.", {
   dt <- genData(n, def)
   dt$test2 <- ceiling(dt$test2)
 
-  expect_length(.genUnifInt(n, "test;test2", dt), n)
-  expect_true(all(!is.na(.genUnifInt(n, "test;test2", dt))))
-  expect_length(.genUnifInt(n, "1;100", dt), n)
+  expect_length(.genUnifInt(n, "test;test2", dt, environment()), n)
+  expect_true(all(!is.na(.genUnifInt(n, "test;test2", dt, environment()))))
+  expect_length(.genUnifInt(n, "1;100", dt, environment()), n)
 })
 
 test_that("'uniformInt' formula checked correctly", {
@@ -62,9 +62,9 @@ test_that("'uniformInt' formula checked correctly", {
       x
     }),
     function(x) {
-      expect_silent(.genUnifInt(x$n, x$range, NULL))
+      expect_silent(.genUnifInt(x$n, x$range, NULL, environment()))
     }
   )
 
-  expect_error(.genUnifInt(3, "1.1;2.4", NULL), "must be integer")
+  expect_error(.genUnifInt(3, "1.1;2.4", NULL, environment()), "must be integer")
 })


### PR DESCRIPTION
So the issue with #59 and with the errors in the documentation I mentioned somewhere was that previously we used parent.frame() WITHIN simstudy. Due to the way environments work, if the ..var was not assigned in an environment upstream from simstudy e.g. the global environment we had no chance to finde the variable.

I add an `envir` argument to the functions that are used to generate data:
 - `addCorFlex`
 - `addColumns`
 - `addCondition`
 - `genData`
And of course all internal functions used by those. This allows for use of double-dot vars in mcapply and other situations with nested/different environments.

Let me know what you think!  

(It was easier then expected if this works correclty :D )