### PR TITLE
Use backports

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,7 +19,9 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: 'oldrel'}
           - {os: macOS-latest, r: 'release'}
+          - {os: macOS-latest, r: 'oldrel'}
           - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: simstudy
 Title: Simulation of Study Data
-Version: 0.2.0.9000
+Version: 0.2.1
 Date: 2020-10-06
 Authors@R: 
     c(person(given = "Keith",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,8 @@ Imports:
     methods,
     mvnfast,
     mvtnorm,
-    Rcpp
+    Rcpp,
+    backports
 Suggests: 
     covr,
     dplyr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# simstudy (development version)
+# simstudy 0.2.1
 
 # simstudy 0.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,16 +30,6 @@
 * Fixed bug in trtAssign when strata had count of one.
 * defData now also checks the first row in the definition table for validity.
 
-
-
-
-
-
-
-
-
-
-
 # simstudy 0.1.16
 
 * Added "mixture" distribution that takes a value from an existing column with a specified probability.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 # simstudy 0.2.1
+* Add 'backports' for compatibility with R < 4.0 
+* Fix a bug on R < 4.0 in genOrdCat
 
 # simstudy 0.2.0
 

--- a/R/asserts.R
+++ b/R/asserts.R
@@ -251,10 +251,12 @@ ensureLength <- function(..., n,
 ensureMatrix <- function(var) {
     stopifnot(is(var, "matrix") || is(var, "vector"))
 
+    if (is(var, "matrix")) {
+        return(var)
+    }
+
     if (is(var, "vector")) {
         return(matrix(var, nrow = 1))
-    } else {
-        return(var)
     }
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,3 @@
+.onLoad <- function(libname, pkgname) {
+  backports::import(pkgname)
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -12,8 +12,6 @@ knitr::opts_chunk$set(
 )
 ```
 
-# simstudy
-
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 <!-- badges: start -->
 [![R build status](https://github.com/kgoldfeld/simstudy/workflows/R-CMD-check/badge.svg?branch=main)](https://github.com/kgoldfeld/simstudy/actions)

--- a/README.md
+++ b/README.md
@@ -1,17 +1,6 @@
 simstudy
 ================
 
-<!-- badges: start -->
-
-[![R build
-status](https://github.com/kgoldfeld/simstudy/workflows/R-CMD-check/badge.svg?branch=main)](https://github.com/kgoldfeld/simstudy/actions)
-[![CRAN
-status](https://www.r-pkg.org/badges/version/simstudy)](https://CRAN.R-project.org/package=simstudy)
-[![codecov](https://codecov.io/gh/kgoldfeld/simstudy/branch/main/graph/badge.svg)](https://codecov.io/gh/kgoldfeld/simstudy)
-<!-- badges: end -->
-
-# simstudy
-
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
 <!-- badges: start -->
@@ -92,17 +81,17 @@ dd <- trtAssign(dd, nTrt = 4, grpName = "grp", balanced = TRUE)
 
 dd
 #>       id         x        y grp
-#>   1:   1  9.614759 8.388761   3
-#>   2:   2  8.286225 7.616225   2
-#>   3:   3 11.035302 9.420590   1
-#>   4:   4 10.333926 8.248654   1
-#>   5:   5 11.199110 9.349459   3
+#>   1:   1  9.902079 7.917103   4
+#>   2:   2  7.994863 7.221989   2
+#>   3:   3 10.365323 8.464112   2
+#>   4:   4  9.264081 8.419645   2
+#>   5:   5  9.450214 8.358625   1
 #>  ---                           
-#> 246: 246  9.276009 7.984796   2
-#> 247: 247  9.086318 6.618701   2
-#> 248: 248  8.628892 5.750542   1
-#> 249: 249  8.823797 8.543863   4
-#> 250: 250 11.527290 9.584074   3
+#> 246: 246 11.362939 8.683527   3
+#> 247: 247  8.369095 8.927575   2
+#> 248: 248 10.212344 9.199797   2
+#> 249: 249  8.040004 7.548118   2
+#> 250: 250  9.190482 6.613247   4
 ```
 
 ## Code of Conduct


### PR DESCRIPTION
We had an [error on CRAN](https://cran.r-project.org/web/checks/check_results_simstudy.html)on windows oldrel. 
This was my failuire I attributed the issues before only to the stringi problem (which was true in the most part)
But I did not see the issue with the R 3.6.3. 
In R 4.0 new options were introduced to `suppressMessages` which will of course cause an unused argument error when used in R < 4.0 (this is only an issue for people trying to run the tests)
This is fixed by using the `backports` package.

Another issue is caused by R < 4.0 considering matrices to be of class `matrix` AND `vector` 
This causes an issue with one of the assert functions converting a matrix into a matrix with one row. 
(This will affect normal users )

I am very sorry for these oversights. I have already added an old release build to our CI to catch issues like this earlier. I will also send this build to rhub to double check.