### PR TITLE
Assign user/issue40

### DIFF
--- a/R/generate_data.R
+++ b/R/generate_data.R
@@ -62,11 +62,11 @@ genData <- function(n, dtDefs = NULL, id = "id", envir = parent.frame()) {
 
     if (id != attr(dtDefs, "id") && !missing(id)) {
       valueWarning(
-        names = "id",
+        names = id,
         msg = list(
-          "The '{names}' parameter is only ",
-          "valid when no definition is supplied ",
-          "and will be ignored."
+          "The 'id' parameter is not valid when previously defined ",
+          "in call to 'defData'. ",
+          "The current specification '{names}' is ignored."
         )
       )
     }

--- a/R/generate_data.R
+++ b/R/generate_data.R
@@ -59,6 +59,17 @@ genData <- function(n, dtDefs = NULL, id = "id", envir = parent.frame()) {
   } else { # existing definitions
     assertClass(dtDefs = dtDefs, class = "data.table")
 
+    if (id != attr(dtDefs, "id") && id != "id") {
+      valueWarning(
+        names = "id",
+        msg = list(
+          "The '{names}' parameter is only ",
+          "valid when no definition is supplied ",
+          "and will be ignored."
+        )
+      )
+    }
+
     idname <- attr(dtDefs, "id")
 
     dfSimulate <- data.frame(c(1:n)) # initialize simulated data with ids

--- a/R/generate_data.R
+++ b/R/generate_data.R
@@ -59,7 +59,7 @@ genData <- function(n, dtDefs = NULL, id = "id", envir = parent.frame()) {
   } else { # existing definitions
     assertClass(dtDefs = dtDefs, class = "data.table")
 
-    if (id != attr(dtDefs, "id") && id != "id") {
+    if (id != attr(dtDefs, "id") && !missing(id)) {
       valueWarning(
         names = "id",
         msg = list(

--- a/R/generate_data.R
+++ b/R/generate_data.R
@@ -4,7 +4,8 @@
 #' @param dtDefs name of definitions data.table/data.frame. If no definitions
 #'  are provided
 #' a data set with ids only is generated.
-#' @param id The string defining the id of the record
+#' @param id The string defining the id of the record. Only valid if no `dtDefs`
+#' is supplied or `id` matches the id name of the definition.
 #' @param envir Environment the data definitions are evaluated in.
 #'  Defaults to [base::parent.frame].
 #' @return A data.table that contains the simulated data.

--- a/tests/testthat/test-generate_data.R
+++ b/tests/testthat/test-generate_data.R
@@ -8,8 +8,10 @@ test_that("data is generated as expected", {
   def <- defData(def, varname = "cat", formula = "test;test2", dist = "categorical")
 
   expect_silent(genData(n, def))
+  expect_warning(genData(n, def, "not-id"), class = "simstudy::valueWarning")
   expect_warning(genData(n, def2), "will be normalized")
   expect_warning(genData(n, def3), "Adding category")
+  # TODO expand test with hedgehog
 })
 
 # genOrdCat ----
@@ -18,7 +20,7 @@ test_that("genOrdCat throws errors.", {
   expect_error(genOrdCat(adjVar = NULL, rho = 1), class = "simstudy::missingArgument")
   expect_error(genOrdCat(NULL, NULL, NULL), class = "simstudy::noValue")
   expect_warning(genOrdCat(genData(1), baseprobs = c(0.5, 0.5), corstr = "notValid"), class = "simstudy::invalidOption")
-  
+
 })
 
 library(magrittr)

--- a/tests/testthat/test-generate_data.R
+++ b/tests/testthat/test-generate_data.R
@@ -9,6 +9,7 @@ test_that("data is generated as expected", {
 
   expect_silent(genData(n, def))
   expect_warning(genData(n, def, "not-id"), class = "simstudy::valueWarning")
+  expect_silent(genData(n, def, "id"))
   expect_warning(genData(n, def2), "will be normalized")
   expect_warning(genData(n, def3), "Adding category")
   # TODO expand test with hedgehog


### PR DESCRIPTION
Fixes #40 
This will now issue a warning when a definition is supplied and the provided id param does not match the definition:
![image](https://user-images.githubusercontent.com/16141871/97450323-e8d0f680-1932-11eb-8175-5ccb5d1f051d.png)
