### PR TITLE
fix genOrdCat error when length(adjVar) == 1 & nCats >1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # simstudy (development version)
 * Added CITATION
-
+* genData now warns that it will ignore an 'id' parameter in case a definition
+  table is also passed.
+* Fix an error in genOrdCat when only a single adjustment variable is given but
+  more than one new category will be created.
+  
 # simstudy 0.2.2
 * Improve documentation and vignettes.
 

--- a/R/generate_data.R
+++ b/R/generate_data.R
@@ -625,7 +625,7 @@ genOrdCat <- function(dtName,
   if (!is.null(adjVar)) {
     adjVar <- ensureLength(
       adjVar = adjVar,
-      n = seq_len(nCats), msg = list(
+      n = nCats, msg = list(
         "Number of categories implied",
         " by baseprobs and adjVar do not match. ",
         "{ dots$names[[1]] } should be",

--- a/tests/testthat/test-generate_data.R
+++ b/tests/testthat/test-generate_data.R
@@ -33,7 +33,8 @@ test_that("ordinal categorical data is generated correctly.", {
   probs_short <- c(.2, .4, .2)
   probs <- c(.2, .2, .6)
   data <- genData(n)
-
+  # TODO more test variable parameter combinations
+  expect_silent(genOrdCat(dtName = data, adjVar = "id", baseprobs = rbind(probs,probs), asFactor = FALSE))
   expect_equal(
     {
       data %>%

--- a/tests/testthat/test-generate_data.R
+++ b/tests/testthat/test-generate_data.R
@@ -34,7 +34,6 @@ test_that("ordinal categorical data is generated correctly.", {
   probs <- c(.2, .2, .6)
   data <- genData(n)
   # TODO more test variable parameter combinations
-  expect_silent(genOrdCat(dtName = data, adjVar = "id", baseprobs = rbind(probs,probs), asFactor = FALSE))
   expect_equal(
     {
       data %>%
@@ -66,6 +65,7 @@ test_that("ordinal categorical data is generated correctly.", {
     classes = "simstudy::optionInvalid")
   })
   set.seed(oldSeed)
+  expect_silent(genOrdCat(dtName = data, adjVar = "id", baseprobs = rbind(probs,probs), asFactor = FALSE))
 })
 
 test_that("deprecation warning shows up.", {


### PR DESCRIPTION
Fixes #83

The issue was caused when checking that adjVar is either of length 1 or same length as the number of categories.
For some reason I passed in a vector instead of a single number, not sure who hit me over the head on that one...

Should be fixed now. Sorry again.