### PR TITLE
Adjust genData behaviour with 'id' param

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # simstudy (development version)
 * Added CITATION
-* genData now warns that it will ignore an 'id' parameter in case a definition
-  table is also passed.
+* genData now warns that a set 'id' parameter will override previously defined 'id' names from the data definition.
+* genData now handles NULL as 'id' value in data definitions (e.g. when definitions are not created via defData etc.) by defaulting to 'id'.
 * Fix an error in genOrdCat when only a single adjustment variable is given but
   more than one new category will be created.
   

--- a/R/generate_data.R
+++ b/R/generate_data.R
@@ -74,7 +74,7 @@ genData <- function(n, dtDefs = NULL, id = "id", envir = parent.frame()) {
         )
       }
     } else {
-      id <- oldId %||% "id"
+      id <- oldId %||% id
     }
 
     dfSimulate <- data.frame(c(1:n)) # initialize simulated data with ids

--- a/R/generate_data.R
+++ b/R/generate_data.R
@@ -4,7 +4,7 @@
 #' @param dtDefs name of definitions data.table/data.frame. If no definitions
 #'  are provided
 #' a data set with ids only is generated.
-#' @param id The string defining the id of the record. 
+#' @param id The string defining the id of the record.
 #' Will override previously set id name with a warning (unless the old value is 'id').
 #' @param envir Environment the data definitions are evaluated in.
 #'  Defaults to [base::parent.frame].
@@ -61,21 +61,23 @@ genData <- function(n, dtDefs = NULL, id = "id", envir = parent.frame()) {
     assertClass(dtDefs = dtDefs, class = "data.table")
 
     oldId <- attr(dtDefs, "id")
-    if (id != oldId && !missing(id) && oldId != "id") {
-      valueWarning(
-        var = oldId,
-        names = id,
-        msg = list(
-          "Previously defined 'id'-column found: '{var}'. ",
-          "The current specification '{names}' will override it."
+    if (id != oldId && !missing(id)) {
+      if (oldId != "id") {
+        valueWarning(
+          var = oldId,
+          names = id,
+          msg = list(
+            "Previously defined 'id'-column found: '{var}'. ",
+            "The current specification '{names}' will override it."
+          )
         )
-      )
+      }
+    } else {
+      id <- oldId %||% "id"
     }
 
-    idname <- attr(dtDefs, "id")
-
     dfSimulate <- data.frame(c(1:n)) # initialize simulated data with ids
-    names(dfSimulate) <- attr(dtDefs, "id") # name first column attribute "id"
+    names(dfSimulate) <- id # name first column attribute "id"
     iter <- nrow(dtDefs) # generate a column of data for each row of dtDefs
 
     for (i in (1:iter)) {
@@ -83,13 +85,13 @@ genData <- function(n, dtDefs = NULL, id = "id", envir = parent.frame()) {
         args = dtDefs[i, ],
         n = n,
         dfSim = dfSimulate,
-        idname = idname,
+        idname = id,
         envir = envir
       )
     }
 
     dt <- data.table::data.table(dfSimulate)
-    data.table::setkeyv(dt, idname)
+    data.table::setkeyv(dt, id)
   }
 
   return(dt[])

--- a/R/generate_data.R
+++ b/R/generate_data.R
@@ -4,8 +4,9 @@
 #' @param dtDefs name of definitions data.table/data.frame. If no definitions
 #'  are provided
 #' a data set with ids only is generated.
-#' @param id The string defining the id of the record.
-#' Will override previously set id name with a warning (unless the old value is 'id').
+#' @param id The string defining the id of the record. Will override previously
+#'  set id name with a warning (unless the old value is 'id'). If the 
+#' id attribute in dtDefs is NULL will default to 'id'.
 #' @param envir Environment the data definitions are evaluated in.
 #'  Defaults to [base::parent.frame].
 #' @return A data.table that contains the simulated data.
@@ -61,7 +62,7 @@ genData <- function(n, dtDefs = NULL, id = "id", envir = parent.frame()) {
     assertClass(dtDefs = dtDefs, class = "data.table")
 
     oldId <- attr(dtDefs, "id")
-    if (id != oldId && !missing(id)) {
+    if (!is.null(oldId) && id != oldId && !missing(id)) {
       if (oldId != "id") {
         valueWarning(
           var = oldId,

--- a/R/generate_data.R
+++ b/R/generate_data.R
@@ -4,8 +4,8 @@
 #' @param dtDefs name of definitions data.table/data.frame. If no definitions
 #'  are provided
 #' a data set with ids only is generated.
-#' @param id The string defining the id of the record. Only valid if no `dtDefs`
-#' is supplied or `id` matches the id name of the definition.
+#' @param id The string defining the id of the record. 
+#' Will override previously set id name with a warning (unless the old value is 'id').
 #' @param envir Environment the data definitions are evaluated in.
 #'  Defaults to [base::parent.frame].
 #' @return A data.table that contains the simulated data.
@@ -60,13 +60,14 @@ genData <- function(n, dtDefs = NULL, id = "id", envir = parent.frame()) {
   } else { # existing definitions
     assertClass(dtDefs = dtDefs, class = "data.table")
 
-    if (id != attr(dtDefs, "id") && !missing(id)) {
+    oldId <- attr(dtDefs, "id")
+    if (id != oldId && !missing(id) && oldId != "id") {
       valueWarning(
+        var = oldId,
         names = id,
         msg = list(
-          "The 'id' parameter is not valid when previously defined ",
-          "in call to 'defData'. ",
-          "The current specification '{names}' is ignored."
+          "Previously defined 'id'-column found: '{var}'. ",
+          "The current specification '{names}' will override it."
         )
       )
     }

--- a/R/internal_utility.R
+++ b/R/internal_utility.R
@@ -388,3 +388,13 @@ zeroPadInts <- function(ints, width = max(nchar(ints))) {
   glueFormat <- glue("[i:0{s}d]", s = width)
   glueFmt(glueFormat, i = ints, .open = "[", .close = "]")
 }
+
+#' if x is.null y "%||%"
+#'
+#' @return x unless thats NULL then y
+#' @noRd
+`%||%` <- function(x, y) {
+    if (is.null(x))
+        y
+    else x
+}

--- a/man/genData.Rd
+++ b/man/genData.Rd
@@ -13,8 +13,8 @@ genData(n, dtDefs = NULL, id = "id", envir = parent.frame())
 are provided
 a data set with ids only is generated.}
 
-\item{id}{The string defining the id of the record. Only valid if no \code{dtDefs}
-is supplied or \code{id} matches the id name of the definition.}
+\item{id}{The string defining the id of the record.
+Will override previously set id name with a warning (unless the old value is 'id').}
 
 \item{envir}{Environment the data definitions are evaluated in.
 Defaults to \link[base:sys.parent]{base::parent.frame}.}

--- a/man/genData.Rd
+++ b/man/genData.Rd
@@ -13,8 +13,9 @@ genData(n, dtDefs = NULL, id = "id", envir = parent.frame())
 are provided
 a data set with ids only is generated.}
 
-\item{id}{The string defining the id of the record.
-Will override previously set id name with a warning (unless the old value is 'id').}
+\item{id}{The string defining the id of the record. Will override previously
+set id name with a warning (unless the old value is 'id'). If the
+id attribute in dtDefs is NULL will default to 'id'.}
 
 \item{envir}{Environment the data definitions are evaluated in.
 Defaults to \link[base:sys.parent]{base::parent.frame}.}

--- a/tests/testthat/test-generate_data.R
+++ b/tests/testthat/test-generate_data.R
@@ -9,6 +9,11 @@ test_that("data is generated as expected", {
 
   expect_silent(genData(n, def))
   expect_warning(genData(n, def, "not-id"), class = "simstudy::valueWarning")
+  expect_equal({
+    data <- genData(n, def, "not-id")
+    print(data)
+    attr(data, "id")
+  }, "not-id")
   expect_silent(genData(n, def, "id"))
   expect_warning(genData(n, def2), "will be normalized")
   expect_warning(genData(n, def3), "Adding category")

--- a/tests/testthat/test-generate_data.R
+++ b/tests/testthat/test-generate_data.R
@@ -1,6 +1,8 @@
 # genData ----
 test_that("data is generated as expected", {
   n <- 20
+  
+  null_def <- defData(varname = "test", formula = .3, dist = "nonrandom", id = NULL)
   def <- defData(varname = "test", formula = .3, dist = "nonrandom", id = "some_id")
   def <- defData(def, varname = "test2", formula = .7, dist = "nonrandom")
   def2 <- defData(def, varname = "cat", formula = "test2;.4", dist = "categorical")
@@ -8,6 +10,7 @@ test_that("data is generated as expected", {
   def <- defData(def, varname = "cat", formula = "test;test2", dist = "categorical")
 
   expect_silent(genData(n, def))
+  expect_silent(genData(n, null_def))
 
   expect_warning(genData(n, def, "not-id"), class = "simstudy::valueWarning")
   expect_equal({

--- a/tests/testthat/test-generate_data.R
+++ b/tests/testthat/test-generate_data.R
@@ -1,20 +1,21 @@
 # genData ----
 test_that("data is generated as expected", {
   n <- 20
-  def <- defData(varname = "test", formula = .3, dist = "nonrandom")
+  def <- defData(varname = "test", formula = .3, dist = "nonrandom", id = "some_id")
   def <- defData(def, varname = "test2", formula = .7, dist = "nonrandom")
   def2 <- defData(def, varname = "cat", formula = "test2;.4", dist = "categorical")
   def3 <- defData(def, varname = "cat", formula = "test2;.2", dist = "categorical")
   def <- defData(def, varname = "cat", formula = "test;test2", dist = "categorical")
 
   expect_silent(genData(n, def))
+
   expect_warning(genData(n, def, "not-id"), class = "simstudy::valueWarning")
   expect_equal({
-    data <- genData(n, def, "not-id")
-    print(data)
-    attr(data, "id")
+    data <- suppressWarnings(genData(n, def, "not-id"))
+    names(data)[1]
   }, "not-id")
-  expect_silent(genData(n, def, "id"))
+  expect_silent(genData(n, def, "some_id"))
+
   expect_warning(genData(n, def2), "will be normalized")
   expect_warning(genData(n, def3), "Adding category")
   # TODO expand test with hedgehog


### PR DESCRIPTION
It will now override any previously set name for the id column with a warning (unless it was the default 'id' name, to avoid superfluous warnings). Also adjusted documentation.

Fixes #89 

```r
def_id <- defData(varname = "b0_rct", formula = 0, variance = 2)
null_id <- defData(varname = "b0_rct", formula = 0, variance = 2, id = NULL)
def_other_id <- defData(varname = "b0_rct", formula = 0, variance = 2, id = "other_id")

no_warn <- genData(5, def_id, id = "rct")
warn <- genData(5, def_other_id, id = "rct")
no_warn2 <- genData(5, def_other_id, id = "other_id")
no_warn3 <- genData(5, null_id)
```