### PR TITLE
make trtAssign/Obesere available as distributions

### DIFF
--- a/R/define_data.R
+++ b/R/define_data.R
@@ -568,8 +568,10 @@ defSurv <- function(dtDefs = NULL,
       uniform = ,
 
       uniformInt = .checkUniform(newform),
+      trtAssign =  .checkCategorical(newform),
+      trtObserve = .isValidArithmeticFormula(newform),
 
-      stop("Unkown distribution.")
+      stop("Unknown distribution.")
     )
 
     invisible(newvar)

--- a/R/define_data.R
+++ b/R/define_data.R
@@ -569,7 +569,6 @@ defSurv <- function(dtDefs = NULL,
 
       uniformInt = .checkUniform(newform),
       trtAssign =  .checkCategorical(newform),
-      trtObserve = .isValidArithmeticFormula(newform),
 
       stop("Unknown distribution.")
     )

--- a/R/generate_data.R
+++ b/R/generate_data.R
@@ -77,8 +77,9 @@ genData <- function(n, dtDefs = NULL, id = "id", envir = parent.frame()) {
       id <- oldId %||% id
     }
 
-    dfSimulate <- data.frame(c(1:n)) # initialize simulated data with ids
-    names(dfSimulate) <- id # name first column attribute "id"
+    dfSimulate <- data.table::data.table(x = 1:n)
+    data.table::setnames(dfSimulate, id)
+    data.table::setkeyv(dfSimulate, id)
     iter <- nrow(dtDefs) # generate a column of data for each row of dtDefs
 
     for (i in (1:iter)) {

--- a/R/generate_dist.R
+++ b/R/generate_dist.R
@@ -105,6 +105,19 @@
       dtSim = dfSim,
       envir = envir
     ),
+    trtAssign = .genAssign(
+      dtName = dfSim,
+      grpName = args$varname,
+      strata = args$variance,
+      ratio = args$formula,
+      balanced = args$link
+    ),
+    trtObserve = .genObserve(
+      dt = dfSim,
+      grpName = args$varname,
+      formulas = args$formula,
+      logit.link = args$link
+    ),
     uniform = .genunif(
       n = n,
       formula = args$formula,
@@ -557,4 +570,31 @@
   unifCont <- stats::runif(n, range$min, range$max + 1)
 
   return(as.integer(floor(unifCont)))
+}
+
+.genAssign <- function(dtName, balanced,
+                      strata, grpName, ratio) {
+  dtName <- as.data.table(dtName)
+  if(strata == 0) {
+    strata <- NULL
+  } else {
+    strata <- .splitFormula(strata)
+  }
+  if (balanced == "identity") {
+    balanced <- TRUE
+  }
+  
+  ratio <- as.numeric(.splitFormula(ratio))
+  nTrt <- length(ratio)
+  trtAssign(dtName, nTrt, balanced, strata, grpName, ratio)[, ..grpName]
+                      }
+
+.genObserve <- function(dt, formulas, logit.link, grpName) {
+  dt <- as.data.table(dt)
+  if (logit.link == "identity") {
+    logit.link <- FALSE
+  } else {
+    logit.link <- TRUE
+  }
+  trtObserve(dt, formulas, logit.link, grpName)[, ..grpName]
 }

--- a/R/generate_dist.R
+++ b/R/generate_dist.R
@@ -582,6 +582,8 @@
   }
   if (balanced == "identity") {
     balanced <- TRUE
+  } else {
+    balanced <- FALSE
   }
   
   ratio <- as.numeric(.splitFormula(ratio))

--- a/R/generate_dist.R
+++ b/R/generate_dist.R
@@ -112,12 +112,6 @@
       ratio = args$formula,
       balanced = args$link
     ),
-    trtObserve = .genObserve(
-      dt = copy(dfSim),
-      grpName = args$varname,
-      formulas = args$formula,
-      logit.link = args$link
-    ),
     uniform = .genunif(
       n = n,
       formula = args$formula,
@@ -595,19 +589,9 @@
     nTrt <- ratio
     ratio <- NULL
   }
-  
+
   trtAssign(
     dtName,
     nTrt, balanced, strata, grpName, ratio
   )[, ..grpName]
-}
-
-.genObserve <- function(dt, formulas, logit.link, grpName) {
-  dt <- as.data.table(dt)
-  if (logit.link == "identity") {
-    logit.link <- FALSE
-  } else {
-    logit.link <- TRUE
-  }
-  trtObserve(dt, formulas, logit.link, grpName)[, ..grpName]
 }

--- a/R/internal_utility.R
+++ b/R/internal_utility.R
@@ -189,7 +189,9 @@
       "uniformInt",
       "negBinomial",
       "exponential",
-      "mixture"
+      "mixture",
+      "trtAssign",
+      "trtObserve"
     )
   }
 

--- a/R/internal_utility.R
+++ b/R/internal_utility.R
@@ -190,8 +190,7 @@
       "negBinomial",
       "exponential",
       "mixture",
-      "trtAssign",
-      "trtObserve"
+      "trtAssign"
     )
   }
 

--- a/tests/testthat/helper-gen_def.R
+++ b/tests/testthat/helper-gen_def.R
@@ -8,7 +8,7 @@ library(hedgehog, pos = 3)
 #   usecase or intent is not clear from the generator naming.
 
 # General Generators ----
-distributions <- .getDists()
+distributions <- .getDists()[1:14]
 gen_dist <- gen.no.shrink(gen.element(distributions))
 
 # beta dist variance
@@ -383,7 +383,7 @@ gen_link_logit <- gen.no.shrink(gen.element(c("identity", "logit")))
 #   This data.table is used in generating complete data definitions. New
 #   Distributios need to be added here to to be included in testing.
 reg <- data.table()
-reg$name <- sort(.getDists())
+reg$name <- sort(.getDists()[1:14])
 reg$formula <- character()
 reg$variance <- "gen_var"
 reg$link <- "gen_id"

--- a/tests/testthat/test-internal_utility.R
+++ b/tests/testthat/test-internal_utility.R
@@ -74,7 +74,7 @@ test_that("probabilities (matrix) are adjusted as documented.", {
 
 # .getDists ----
 test_that("number of Dists is up to date.", {
-  expect_length(.getDists(), 14)
+  expect_length(.getDists(), 16)
 })
 
 # .isFormulaScalar ----

--- a/tests/testthat/test-internal_utility.R
+++ b/tests/testthat/test-internal_utility.R
@@ -74,7 +74,7 @@ test_that("probabilities (matrix) are adjusted as documented.", {
 
 # .getDists ----
 test_that("number of Dists is up to date.", {
-  expect_length(.getDists(), 16)
+  expect_length(.getDists(), 15)
 })
 
 # .isFormulaScalar ----


### PR DESCRIPTION
Closes #69 

I added both `trtAssing` and `trtObserve` as distributions. @kgoldfeld could you check it out and let me know if this works for you? I took the parameters assignment out of #69:
 
trtAssign:
* grpName = varname
* strata = variance
* ratio = formula
* balanced = link ("identity" will turn to `TRUE` everything else to `FALSE`)
* nTrt = `length(ratio)`

trtObserve
* grpName = varname
* fomulas = formula
* logit.link = link ("identity" will turn to `FALSE` everything else to `TRUE`)

I haven't added them to the distribution table or anything, if you could add some documentation that would be great!

