### PR TITLE
Use new Github citation feature

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,3 +22,4 @@
 ^paper$
 ^touchstone$
 ^bench$
+^CITATION\.cff$

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -1,0 +1,61 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# The action runs when:
+# - A new release is published
+# - The DESCRIPTION or inst/CITATION are modified
+# - Can be run manually
+# For customizing the triggers, visit https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
+on:
+  release:
+    types: [published]
+  push:
+    paths:
+      - DESCRIPTION
+      - inst/CITATION
+  workflow_dispatch:
+
+name: Update CITATION.cff
+
+jobs:
+  update-citation-cff:
+    runs-on: macos-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v1
+        with:
+          extra-packages: |
+            cffr
+            V8
+
+      - name: Update CITATION.cff
+        run: |
+
+          library(cffr)
+
+          # Customize with your own code
+          # See https://docs.ropensci.org/cffr/articles/cffr.html
+
+          # Write your own keys
+          mykeys <- list()
+
+          # Create your CITATION.cff file
+          cff_write(keys = mykeys)
+
+        shell: Rscript {0}
+
+      - name: Commit results
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add CITATION.cff
+          git commit -m 'Update CITATION.cff' || echo "No changes to commit"
+          git push origin || echo "No changes to commit"
+
+
+

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,62 @@
+# -----------------------------------------------------------
+# CITATION file created with {cffr} R package, v0.1.1
+# See also: https://docs.ropensci.org/cffr/
+# -----------------------------------------------------------
+ 
+cff-version: 1.2.0
+message: 'To cite package "simstudy" in publications use:'
+type: software
+license: GPL-3.0-only
+title: 'simstudy: Simulation of Study Data'
+version: 0.3.0.9000
+doi: 10.21105/joss.02763
+abstract: Simulates data sets in order to explore modeling techniques or better understand
+  data generating processes. The user specifies a set of relationships between covariates,
+  and generates data based on these specifications. The final data sets can represent
+  data from randomized control trials, repeated measure (longitudinal) designs, and
+  cluster randomized trials. Missingness can be generated using various mechanisms
+  (MCAR, MAR, NMAR).
+authors:
+- family-names: Goldfeld
+  given-names: Keith
+  email: keith.goldfeld@nyulangone.org
+  orcid: https://orcid.org/0000-0002-0292-8780
+- family-names: Wujciak-Jens
+  given-names: Jacob
+  email: jacob@wujciak.de
+  orcid: https://orcid.org/0000-0002-7281-3989
+preferred-citation:
+  type: article
+  title: 'simstudy: Illuminating research methods through data generation'
+  authors:
+  - family-names: Goldfeld
+    given-names: Keith
+  - family-names: Wujciak-Jens
+    given-names: Jacob
+  publisher:
+    name: The Open Journal
+  journal: Journal of Open Source Software
+  year: '2020'
+  volume: '5'
+  number: '54'
+  pages: '2763'
+  url: https://doi.org/10.21105/joss.02763
+  doi: 10.21105/joss.02763
+repository: https://CRAN.R-project.org/package=simstudy
+repository-code: https://github.com/kgoldfeld/simstudy
+url: https://kgoldfeld.github.io/simstudy/
+date-released: '2021-11-04'
+contact:
+- family-names: Goldfeld
+  given-names: Keith
+  email: keith.goldfeld@nyulangone.org
+  orcid: https://orcid.org/0000-0002-0292-8780
+keywords:
+- data-generation
+- data-simulation
+- r
+- simulation
+- statistical-models
+identifiers:
+- type: url
+  value: https://kgoldfeld.github.io/simstudy/dev/

--- a/codemeta.json
+++ b/codemeta.json
@@ -5,7 +5,7 @@
   ],
   "@type": "SoftwareSourceCode",
   "identifier": "simstudy",
-  "description": "Simulates data sets in order to explore modeling\n    techniques or better understand data generating processes. The user\n    specifies a set of relationships between covariates, and generates\n    data based on these specifications. The final data sets can represent\n    data from randomized control trials, repeated measure (longitudinal)\n    designs, and cluster randomized trials. Missingness can be generated\n    using various mechanisms (MCAR, MAR, NMAR).",
+  "description": "Simulates data sets in order to explore modeling techniques or better understand data generating processes. The user specifies a set of relationships between covariates, and generates data based on these specifications. The final data sets can represent data from randomized control trials, repeated measure (longitudinal) designs, and cluster randomized trials. Missingness can be generated using various mechanisms (MCAR, MAR, NMAR).",
   "name": "simstudy: Simulation of Study Data",
   "codeRepository": "https://github.com/kgoldfeld/simstudy",
   "relatedLink": [
@@ -15,13 +15,13 @@
   ],
   "issueTracker": "https://github.com/kgoldfeld/simstudy/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.2.2",
+  "version": "0.3.0.9000",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 4.0.2 (2020-06-22)",
+  "runtimePlatform": "R version 4.1.2 (2021-11-01)",
   "provider": {
     "@id": "https://cran.r-project.org",
     "@type": "Organization",
@@ -33,7 +33,7 @@
       "@type": "Person",
       "givenName": "Keith",
       "familyName": "Goldfeld",
-      "email": "Keith.Goldfeld@nyumc.org",
+      "email": "keith.goldfeld@nyulangone.org",
       "@id": "https://orcid.org/0000-0002-0292-8780"
     },
     {
@@ -52,7 +52,7 @@
       "@type": "Person",
       "givenName": "Keith",
       "familyName": "Goldfeld",
-      "email": "Keith.Goldfeld@nyumc.org",
+      "email": "keith.goldfeld@nyulangone.org",
       "@id": "https://orcid.org/0000-0002-0292-8780"
     }
   ],
@@ -270,6 +270,18 @@
         "url": "https://cran.r-project.org"
       },
       "sameAs": "https://CRAN.R-project.org/package=testthat"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "gtsummary",
+      "name": "gtsummary",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=gtsummary"
     }
   ],
   "softwareRequirements": [
@@ -357,16 +369,50 @@
       "sameAs": "https://CRAN.R-project.org/package=backports"
     }
   ],
-  "releaseNotes": "https://github.com/kgoldfeld/simstudy/blob/main/NEWS.md",
+  "releaseNotes": "https://github.com/kgoldfeld/simstudy/blob/master/NEWS.md",
   "readme": "https://github.com/kgoldfeld/simstudy/blob/main/README.md",
-  "fileSize": "8057.013KB",
-  "contIntegration": "https://codecov.io/gh/kgoldfeld/simstudy",
-  "developmentStatus": "https://www.tidyverse.org/lifecycle/#stable",
+  "fileSize": "6381.75KB",
+  "contIntegration": ["https://github.com/kgoldfeld/simstudy/actions", "https://app.codecov.io/gh/kgoldfeld/simstudy"],
+  "developmentStatus": "https://lifecycle.r-lib.org/articles/stages.html",
   "keywords": [
     "r",
     "data-simulation",
     "data-generation",
     "simulation",
     "statistical-models"
+  ],
+  "citation": [
+    {
+      "@type": "ScholarlyArticle",
+      "datePublished": "2020",
+      "author": [
+        {
+          "@type": "Person",
+          "givenName": "Keith",
+          "familyName": "Goldfeld"
+        },
+        {
+          "@type": "Person",
+          "givenName": "Jacob",
+          "familyName": "Wujciak-Jens"
+        }
+      ],
+      "name": "simstudy: Illuminating research methods through data generation",
+      "identifier": "10.21105/joss.02763",
+      "url": "https://doi.org/10.21105/joss.02763",
+      "pagination": "2763",
+      "@id": "https://doi.org/10.21105/joss.02763",
+      "sameAs": "https://doi.org/10.21105/joss.02763",
+      "isPartOf": {
+        "@type": "PublicationIssue",
+        "issueNumber": "54",
+        "datePublished": "2020",
+        "isPartOf": {
+          "@type": ["PublicationVolume", "Periodical"],
+          "volumeNumber": "5",
+          "name": "Journal of Open Source Software"
+        }
+      }
+    }
   ]
 }


### PR DESCRIPTION
Github has recently introduced a new feature to help people cite software correctly this looks like this:
![cff_example](https://user-images.githubusercontent.com/16141871/143312974-0c375654-a935-4e3d-bbc8-7b6069e00e6f.png)

I think that is pretty cool and it is hassle free to implement thanks to the [{cffr}](https://cran.r-project.org/package=cffr) package which parses the `CITATION` file and generates the correct `CITATION.cff` file and also comes with a github action that runs in case the `CITATION` or `DESCRIPTION` where changed, so it will always be up to date!

