### PR TITLE
Update pkgdown.yaml

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: | 
-            pkgdown
+            github::r-lib/pkgdown
             local::.
       - name: Deploy package
         run: |


### PR DESCRIPTION
Workaround for https://github.com/r-lib/pkgdown/issues/2126 until {pkgdown} >2.0.4 is on CRAN