### PR TITLE
Fix "key" bug in .EvalWith

### DIFF
--- a/R/internal_utility.R
+++ b/R/internal_utility.R
@@ -66,14 +66,15 @@
 
   if (!missing(dtSim) && !is.null(dtSim)) {
     e$dtSim <- as.data.table(dtSim)
-    e$def_id <- names(dtSim)[[1]]
-  }
+    # e$def_id <- names(dtSim)[[1]] # original, but incorrect
+    e$def_id <- key(dtSim)
+    }
 
   if (missing(dtSim) || is.null(dtSim)) {
     e$dtSim <- genData(n)
     e$def_id <- "id"
   }
-
+  
   if (!is.null(e$formula2parse)) {
     stop("'formula2parse' is a reserved variable name!")
   }


### PR DESCRIPTION
There was a bug in `.evalWith` that automatically assumed the first column was the data.table key. This is not always the case, particularly when cluster data or period data has been generated, and the key is converted to the finer grain id. (The first field might now be repeating). It has been fixed, and I am quite certain it should not impact anything. All the tests passed, so that provides some level of comfort that I did not break anything with the change. In any case, this fix should eliminate some weird behavior.