### PR TITLE
Modifying .genclustersize

### DIFF
--- a/R/asserts.R
+++ b/R/asserts.R
@@ -104,9 +104,9 @@ assertAtLeastLength <- function(..., length, call = sys.call(-1)) {
   }
 }
 
-#' Are all elements of vector probabilities?
+#' Are all elements greater than or equal to a value?
 #'
-#' @description Checks if passed vector includes only proper probabilities
+#' @description Checks if passed vector is >= a minimum value
 #' @param vec Vector under consideration
 #' @noRd
 assertAtLeast <- function(..., minVal, call = sys.call(-1)) {

--- a/vignettes/clustered.Rmd
+++ b/vignettes/clustered.Rmd
@@ -126,9 +126,8 @@ genData(7, d1, id = "site")
 This is a second example with variability across sites:
 
 ```{r}
-d1 <- defData(varname = "randEffect", formula = 0, variance = 1, dist = "normal")
-d1 <- defData(d1, varname = "clustSize", formula = 120, 
-  variance = .05, dist = "clusterSize")
+d1 <- defData(varname = "clustSize", formula = 120, 
+  variance = .1, dist = "clusterSize")
 
 genData(8, d1, id = "site")
 ```


### PR DESCRIPTION
I realized that the original conception of `.genclustersize` induced too much variability in cluster sizes by using both the dirichlet and multinomial distributions. Even a low dispersion parameter resulted in fairly substantial variability across clusters. It has been changed so that only the dirichlet distribution is used.