### PR TITLE
feat(add_correlated_data): warn if addCorGen idname is not unique

### DIFF
--- a/R/add_correlated_data.R
+++ b/R/add_correlated_data.R
@@ -57,8 +57,17 @@
 #' round(cor(dtAdd[, .(V1, V2, V3)]), 2)
 #' @concept correlated
 #' @export
-addCorData <- function(dtOld, idname, mu, sigma, corMatrix = NULL,
+addCorData <- function(dtOld, idname = "id", mu, sigma, corMatrix = NULL,
                        rho, corstr = "ind", cnames = NULL) {
+  # addCorData will produce odd results if `idname` appears multiple times in
+  # `dtOld`. Thus, we check and omit a warning.
+  if (length(unique(dtOld[, idname])) != nrow(dtOld)) {
+    valueWarning(
+      names = c("dtOld"),
+      msg = "`idname` appears multiple times in `dtOld`. Check results."
+    )
+  }
+
   # dtName must contain id for now
   dtTemp <- copy(dtOld)
   data.table::setkeyv(dtTemp, idname)

--- a/tests/testthat/test-generate_correlated_data.R
+++ b/tests/testthat/test-generate_correlated_data.R
@@ -398,6 +398,22 @@ test_that("genCorMat generates errors correctly.", {
 
 # addCorData ----
 
+test_that("addCorData emits warning if `idname` appears multiple times", {
+  tdef <- defData(varname = "grp", dist = "binary", formula = 0.5, id = "id")
+
+  dt <- genData(500, tdef)
+  dt <- rbind(dt, dt)
+
+  mu <- rnorm(3, mean = c(3, 8, 15))
+  sigma <- rgamma(3, 1.5, 1)
+  corMat <- genCorMat(3)
+
+  expect_warning(
+    addCorData(dt, "id", mu = mu, sigma = sigma, corMat = corMat),
+    "`idname` appears multiple times in `dtOld`. Check results."
+  )
+})
+
 test_that("addCorData adds correlated data with compound symmetry structure", {
 
   skip_on_cran()


### PR DESCRIPTION
Hello,

thanks for putting all this work into simstudy! I really like the package ;)

In the current stable version, the following code produces odd results (the example is adapted from your test file):

```r
tdef <- defData(varname = "grp", dist = "binary", formula = 0.5, id = "id")

dt <- genData(500, tdef)

dtTime <- addPeriods(
  dt,
  nPeriods = 3,
  idvars = c("id", "grp")
)

mu <- rnorm(3, mean = c(3, 8, 15))
sigma <- rgamma(3, 1.5, 1)
corMat <- genCorMat(3)
dtAdd <- addCorData(dtTime, "id", mu = mu, sigma = sigma, corMat = corMat)
```

While `dtTime` has 1500 rows, `dtAdd` has 2500 rows.

This is due the [this line](https://github.com/kgoldfeld/simstudy/blob/9a66528a067aab92cf94238ac2f3b20e84097d52/R/add_correlated_data.R#L66) in `addCorData`. Instead of creating as many rows as there are unique `ids`, the number of rows in the input data frame are created (and added to the returned data frame). Thus, the current PR fixes this issue.

In the current main branch this problem does not exist as `mergeData` was changed to do a left inner join per default (the rows that are too many are simply thrown away). In addition, the data generating process seems to produce also the correct correlation matrix in a subsample (the first 500 rows).

Nonetheless, I think it's worth to fix this issue as it is still a logic error. I tried to create a test case for this issue but failed due to the latest changes in the main branch. As a side effect, I set the default value of `idname` to `id` as described in the help page.

Thanks for your time considering this PR.